### PR TITLE
add overylayname and unique_key in pr branch name

### DIFF
--- a/src/commit-and-pull-request.sh
+++ b/src/commit-and-pull-request.sh
@@ -92,7 +92,7 @@ if [[ "${PROMOTION_METHOD}" == "pull_request" ]]; then
       git checkout -B "${BRANCH}"
     fi
   else
-    BRANCH="$(echo "promotion/${GITHUB_REPOSITORY:?}/${TARGET_BRANCH:?}/${GITHUB_SHA:?}" | tr "/" "-")"
+    BRANCH="$(echo "promotion/${GITHUB_REPOSITORY:?}/${TARGET_BRANCH:?}/${OVERLAY_NAMES_NO_SLASH:?}/${PR_UNIQUE_KEY:?}/${GITHUB_SHA:?}" | tr "/" "-")"
     git checkout -B "${BRANCH}"
   fi
 


### PR DESCRIPTION
In PROs case, we were hitting line 95 (not using aggregated PRs), but we were also deploying the same commit SHA to 3 different overlays. This caused an issue b/c the branch already matched the _first_ PR that was created, and the other overlay branches were considered "not needed".

Hopefully adding the overlay name into line 95 will help