### PR TITLE
delete the branches after successful merge

### DIFF
--- a/src/commit-and-pull-request.sh
+++ b/src/commit-and-pull-request.sh
@@ -125,7 +125,7 @@ if [[ "${PROMOTION_METHOD}" == "pull_request" ]]; then
   echo
   if [[ "${AUTO_MERGE}" == "true" ]]; then
     echo "Status checks have all passed. Merging PR..."
-    gh pr merge --squash --admin
+    gh pr merge --squash --admin --delete-branch
     echo
     echo "Promotion PR has been merged. Details below."
   else


### PR DESCRIPTION
This would help in the scenario where the source code is a commit "roll back" and not a revert commit. w/o this, the original branch with SHA will still exist and thus won't create a new PR