### PR TITLE
don't run gh pr merge twice

### DIFF
--- a/src/commit-and-pull-request.sh
+++ b/src/commit-and-pull-request.sh
@@ -142,7 +142,6 @@ if [[ "${PROMOTION_METHOD}" == "pull_request" ]]; then
       echo "retrying in 5 seconds..."
       sleep 5
     done
-    gh pr merge --squash --admin --delete-branch
     echo
     echo "Promotion PR has been merged. Details below."
   else


### PR DESCRIPTION
we mistakenly ran `gh pr merge` twice when retrying. 